### PR TITLE
Improve default settings and ordering

### DIFF
--- a/To_Do/core/settings.py
+++ b/To_Do/core/settings.py
@@ -21,12 +21,13 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('DJANGO_SECRET')
+SECRET_KEY = os.getenv('DJANGO_SECRET', 'insecure-secret-key')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DJANGO_DEBUG', 'False') == 'True'
 
-ALLOWED_HOSTS = os.getenv('DJANGO_ALLOWED_HOSTS', '').split(',')
+allowed_hosts = os.getenv('DJANGO_ALLOWED_HOSTS')
+ALLOWED_HOSTS = allowed_hosts.split(',') if allowed_hosts else []
 
 
 # Application definition
@@ -77,16 +78,25 @@ WSGI_APPLICATION = 'core.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv('POSTGRES_DB'),
-        'USER': os.getenv('POSTGRES_USER'),
-        'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
-        'HOST': os.getenv('POSTGRES_HOST'),
-        'PORT': os.getenv('POSTGRES_PORT', '5432'),
+POSTGRES_DB = os.getenv('POSTGRES_DB')
+if POSTGRES_DB:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': POSTGRES_DB,
+            'USER': os.getenv('POSTGRES_USER'),
+            'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
+            'HOST': os.getenv('POSTGRES_HOST'),
+            'PORT': os.getenv('POSTGRES_PORT', '5432'),
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'db.sqlite3',
+        }
+    }
 
 
 # Password validation

--- a/To_Do/todo/views.py
+++ b/To_Do/todo/views.py
@@ -4,5 +4,5 @@ from todo.serializers import TaskSerializer
 
 
 class TaskViewSet(viewsets.ModelViewSet):
-    queryset = Task.objects.all()
+    queryset = Task.objects.all().order_by('id')
     serializer_class = TaskSerializer

--- a/To_Do/todo/views.py
+++ b/To_Do/todo/views.py
@@ -4,5 +4,5 @@ from todo.serializers import TaskSerializer
 
 
 class TaskViewSet(viewsets.ModelViewSet):
-    queryset = Task.objects.all().order_by('id')
+    queryset = Task.objects.all().order_by('-id')
     serializer_class = TaskSerializer


### PR DESCRIPTION
## Summary
- provide default SECRET_KEY and ALLOWED_HOSTS
- use SQLite when Postgres variables are missing
- keep task list ordering stable

## Testing
- `python To_Do/manage.py test todo -v 2`

------
https://chatgpt.com/codex/tasks/task_e_685f660c5cb08320b69435fccdca6765