### PR TITLE
Update README DB variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ DJANGO_DEBUG=True
 DJANGO_SECRET=django-insecure-key
 DJANGO_ALLOWED_HOSTS=localhost
 
-POSTGRES_DB=my__database
+POSTGRES_DB=my_database
 POSTGRES_USER=my_user
 POSTGRES_PASSWORD=my_password
 POSTGRES_HOST=db


### PR DESCRIPTION
## Summary
- fix typo in DB name in environment example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f6bc095048320be1aaa41cdd3ef96