### PR TITLE
Refine CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - main
       - dev
+    paths:
+      - '**/*.py'
   pull_request:
     branches:
       - main
       - dev
+    paths:
+      - '**/*.py'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- run CI workflow only on Python file changes

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `flake8 To_Do` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6ffb6eb08320aedee27f90896e60